### PR TITLE
Backup to and Restore from locations SQL doesn't have access too

### DIFF
--- a/DatabaseBackupTool/Backup.cs
+++ b/DatabaseBackupTool/Backup.cs
@@ -244,13 +244,13 @@ namespace DatabaseBackupTool
             else
             {
                 useTemporaryPath = true;
-                if (!Directory.Exists(temporaryBackupPath)) //if directory does not exist
+                if (!Directory.Exists(temporaryBackupPath))
                 {
                     Directory.CreateDirectory(temporaryBackupPath);
                 }
             }
 
-            if (backgroundWorker1.IsBusy)
+            if (backgroundWorker1.IsBusy || backgroundWorker3.IsBusy)
                 return;
 
             backupProgressBar.Value = 0;

--- a/DatabaseBackupTool/Backup.cs
+++ b/DatabaseBackupTool/Backup.cs
@@ -436,7 +436,7 @@ namespace DatabaseBackupTool
                             connector2.Close();
                         }
                         if (useTemporaryPath)
-                            File.Move($"{temporaryBackupPath}\\{file}", $"{backupDirectoryTextBox.Text}\\{file}");
+                            File.Copy($"{temporaryBackupPath}\\{file}", $"{backupDirectoryTextBox.Text}\\{file}", true);
                         Logger.Info($"Successfully Backed Up Database: {backupList.Items[i]}");
                     }
                     catch (Exception ex)

--- a/DatabaseBackupTool/Backup.cs
+++ b/DatabaseBackupTool/Backup.cs
@@ -115,15 +115,15 @@ namespace DatabaseBackupTool
                         databases.Add(reader[0].ToString());
                     }
                     reader.Close();
-                    if (connector.GetConnectionState() == ConnectionState.Open)
-                    {
+                    if (connector.GetConnectionState() != ConnectionState.Closed)
                         connector.Close();
-                    }
                 }
                 return databases;
             }
             catch (Exception e)
             {
+                if (connector.GetConnectionState() == ConnectionState.Open)
+                    connector.Close();
                 Console.WriteLine($"{e}: There was an error while retrieving the database list.");
                 return databases;
             }
@@ -279,10 +279,8 @@ namespace DatabaseBackupTool
         {
             try
             {
-                if (connector.GetConnectionState() == ConnectionState.Closed)
+                if (connector.GetConnectionState() != ConnectionState.Open)
                     connector.Open();
-                else
-                    connector.Close();
 
                 String lastSys2 = backupList.Items[backupList.Items.Count - 1].ToString();
                 String tempDatabase = "SqlWriteAccess";
@@ -292,9 +290,7 @@ namespace DatabaseBackupTool
                 command.CommandTimeout = 0;
                 var reader = connector.ReadResults(command);
 
-                if (connector.GetConnectionState() == ConnectionState.Closed)
-                    connector.Open();
-                else
+                if (connector.GetConnectionState() != ConnectionState.Closed)
                     connector.Close();
 
                 if (File.Exists(file))
@@ -307,6 +303,8 @@ namespace DatabaseBackupTool
             }
             catch
             {
+                if (connector.GetConnectionState() == ConnectionState.Open)
+                    connector.Close();
                 return false;
             }
         }


### PR DESCRIPTION
Makes use of a temporary folder as an intermediary. 

Backing up to a folder SQL doesn't have direct access to results in SQL backing up to C:/tempDir (that it creates) and then moving each of the backup files out of the temp folder to the desired folder before deleting the temp folder

Restoring will copy all bak files (still using the recursive flag) to that same temporary folder that it creates before restoring each of those bak files from the temp folder. Temp folder is deleted after restoring is complete.

I feel like this deserves a minor rev change. Please feel free to disagree