### PR TITLE
Fix some file exceptions + Cleanup

### DIFF
--- a/DatabaseBackupTool/Dashboard.Designer.cs
+++ b/DatabaseBackupTool/Dashboard.Designer.cs
@@ -76,6 +76,7 @@ namespace DatabaseBackupTool
             this.MaximizeBox = false;
             this.Name = "Dashboard";
             this.Text = "Dashboard";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Dashboard_FormClosing);
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/DatabaseBackupTool/Dashboard.cs
+++ b/DatabaseBackupTool/Dashboard.cs
@@ -74,5 +74,11 @@ namespace DatabaseBackupTool
             ef.ControlBox = false;
             ef.ShowDialog();
         }
+
+        private void Dashboard_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            if (System.IO.Directory.Exists(@"C:\BackupAndRestoreTempFolder"))
+                System.IO.Directory.Delete(@"C:\BackupAndRestoreTempFolder", recursive: true);
+        }
     }
 }

--- a/DatabaseBackupTool/Restore.cs
+++ b/DatabaseBackupTool/Restore.cs
@@ -104,7 +104,7 @@ namespace DatabaseBackupTool
                 foreach (string bakFile in BAK_files)
                 {
                     FileInfo fileToCopy = new FileInfo(bakFile);
-                    fileToCopy.CopyTo($@"{temporaryBackupPath}\{fileToCopy.Name}");
+                    fileToCopy.CopyTo($@"{temporaryBackupPath}\{fileToCopy.Name}", overwrite: true);
                 }
             }
 


### PR DESCRIPTION
Problem: an error in restore led to the temporary folder to not be deleted
Solution: delete temp folder (if exists) on close of Dashboard

Problem: selecting multiple files with the same name (recurse option)
Solution: enable overwrite 