### PR TITLE
FolderBrowserDialogs Initial Value When Opened Now Matches the Path TextBox

### DIFF
--- a/DatabaseBackupTool/Backup.cs
+++ b/DatabaseBackupTool/Backup.cs
@@ -313,7 +313,7 @@ namespace DatabaseBackupTool
         {
             FolderBrowserDialog fbd = new FolderBrowserDialog();
             fbd.SelectedPath = backupDirectoryTextBox.Text;
-            fbd.ShowDialog();
+            fbd.ShowDialog(true);
             backupDirectoryTextBox.Text = fbd.SelectedPath;
         }
 

--- a/DatabaseBackupTool/DatabaseToolKit.csproj
+++ b/DatabaseBackupTool/DatabaseToolKit.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Backup.Designer.cs">
       <DependentUpon>Backup.cs</DependentUpon>
     </Compile>
+    <Compile Include="ExtensionMethods.cs" />
     <Compile Include="HelperClass.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/DatabaseBackupTool/ExtensionMethods.cs
+++ b/DatabaseBackupTool/ExtensionMethods.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace DatabaseBackupTool
+{
+internal static class FolderBrowserDialogExtension
+{
+    public static DialogResult ShowDialog(this FolderBrowserDialog dialog, bool scrollIntoView)
+    {
+        return ShowDialog(dialog, null, scrollIntoView);
+    }
+
+    public static DialogResult ShowDialog(this FolderBrowserDialog dialog, IWin32Window owner, bool scrollIntoView)
+    {
+        if (scrollIntoView)
+        {
+            SendKeys.Send("{TAB}{TAB}{RIGHT}");
+        }
+
+        return dialog.ShowDialog(owner);
+    }
+}
+}

--- a/DatabaseBackupTool/Restore.cs
+++ b/DatabaseBackupTool/Restore.cs
@@ -51,7 +51,7 @@ namespace DatabaseBackupTool
         {
             FolderBrowserDialog fbd = new FolderBrowserDialog();
             fbd.SelectedPath = restoreDirectoryTextBox.Text;
-            fbd.ShowDialog();
+            fbd.ShowDialog(true);
             restoreDirectoryTextBox.Text = fbd.SelectedPath;
         }
 


### PR DESCRIPTION
Closes #80 

## Description
Covers issue #80 . This issue requests the starting location of the FBDs (FolderBrowserDialogs) to be the value in the path textbox. ~~Unfortunately, the amount of [work ](https://stackoverflow.com/a/15440926)it will take to make the FBDs scroll to the selected value is not worth it IMO.~~ (NEVERMIND, SEE [this](https://stackoverflow.com/a/39422444) . There seem to be some inconsistencies when the control auto scrolls to the selected item. Nothing catastrophic .

## Testing (These should be done for both the **BACKUP** and **RESTORE** forms):

####
Existing Directory
- Change the backup path text box to a existing directory
- Click the "path" button
- Ensure the selected path is selected when opening the FBD

####
Non-Existing Directory
- Change the backup path text box to a non-existing directory
- Click the "path" button
- Ensure the selected path of the FBD is that of "Desktop" or that no errors are reported.
- Without changing the selected path of the FBD, attempt to use the functionality (backup or restore depending on which form you are on) and ensure it is successful. 